### PR TITLE
Merge Develop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "threader"
-version = "0.0.3"
+version = "0.1.0"
 authors = ["Factorial"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "threader"
-version = "0.1.0"
+version = "0.0.4"
 authors = ["Factorial"]
 edition = "2018"
 

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -230,6 +230,98 @@ impl AsyncWrite for TcpStream {
     }
 }
 
+// =============== TcpListener =============== //
+
+#[derive(Debug)]
+pub struct TcpListener {
+    observer: Observer<MioTcpListener>,
+}
+
+impl TcpListener {
+    pub fn bind(addr: &SocketAddr) -> io::Result<Self> {
+        let listener = MioTcpListener::bind(&addr)?;
+        let observer = observer_listener(listener)?;
+
+        match observer.get_ref().take_error()? {
+            Some(err) => Err(err),
+            None => Ok(Self { observer }),
+        }
+    }
+
+    pub fn from_std(listener: StdTcpListener) -> io::Result<Self> {
+        let listener = MioTcpListener::from_std(listener)?;
+        let observer = observer_listener(listener)?;
+
+        match observer.get_ref().take_error()? {
+            Some(err) => Err(err),
+            None => Ok(Self { observer }),
+        }
+    }
+
+    pub async fn accept_std(&self) -> io::Result<StdTcpStream> {
+        use io::ErrorKind::WouldBlock;
+
+        let stream = loop {
+            match self.observer.get_ref().accept_std() {
+                Ok((stream, _)) => break stream,
+                Err(e) if !is_retry(&e) => return Err(e),
+                Err(e) if e.kind() == WouldBlock => {
+                    self.observer.reregister(rw(), PollOpt::edge())?;
+                    self.observer.await_readable().await;
+                }
+                _ => (), // interrupted.
+            }
+        };
+
+        match stream.take_error()? {
+            Some(err) => Err(err),
+            None => Ok(stream),
+        }
+    }
+
+    pub async fn accept(&self) -> io::Result<TcpStream> {
+        use io::ErrorKind::WouldBlock;
+
+        let stream = loop {
+            match self.observer.get_ref().accept() {
+                Ok((stream, _)) => break stream,
+                Err(e) if !is_retry(&e) => return Err(e),
+                Err(e) if e.kind() == WouldBlock => {
+                    self.observer.reregister(rw(), PollOpt::edge())?;
+                    self.observer.await_readable().await;
+                }
+                _ => (), // interrupted.
+            }
+        };
+        let observer = observer_stream(stream)?;
+
+        match observer.get_ref().take_error()? {
+            Some(err) => Err(err),
+            None => Ok(TcpStream { observer }),
+        }
+    }
+
+    pub fn local_addr(&self) -> io::Result<SocketAddr> {
+        self.observer.get_ref().local_addr()
+    }
+
+    pub fn set_ttl(&self, ttl: u32) -> io::Result<()> {
+        self.observer.get_ref().set_ttl(ttl)
+    }
+
+    pub fn ttl(&self) -> io::Result<u32> {
+        self.observer.get_ref().ttl()
+    }
+
+    pub fn set_only_v6(&self, only_v6: bool) -> io::Result<()> {
+        self.observer.get_ref().set_only_v6(only_v6)
+    }
+
+    pub fn only_v6(&self) -> io::Result<bool> {
+        self.observer.get_ref().only_v6()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -238,19 +330,52 @@ mod tests {
     use crossbeam::channel;
     use once_cell::sync::Lazy;
 
-    static EX: Lazy<ThreadPool> = Lazy::new(|| ThreadPool::new().unwrap());
+    static EX: Lazy<ThreadPool> = Lazy::new(|| ThreadPool::with_threads(1).unwrap());
 
     #[test]
+    #[ignore]
+    // Ignored because the IP may not be valid on
+    // your network.
     fn connect_test() {
         let (tx, rx) = channel::unbounded();
 
         EX.spawn(async move {
             let addr = "10.0.0.1:80".parse().unwrap();
             let stream = TcpStream::connect(&addr).await;
-            let res = dbg!(stream).map(|_| ()).map_err(|_| ());
-            tx.send(res).unwrap();
+            let _ = dbg!(stream);
+            tx.send(0).unwrap();
+        });
+
+        assert_eq!(rx.recv(), Ok(0));
+    }
+
+    #[test]
+    fn listener_stream_connect() {
+        let (tx, rx) = channel::unbounded();
+        let (tx2, rx2) = channel::unbounded();
+
+        EX.spawn(async move {
+            let addr = "127.0.0.1:25565".parse().unwrap();
+            let listener = dbg!(TcpListener::bind(&addr));
+            match listener {
+                Err(_) => tx.send(Err(())).unwrap(),
+                Ok(listener) => {
+                    let res = listener.accept().await.map(|_| ()).map_err(|_| ());
+                    tx.send(res).unwrap()
+                }
+            }
+        });
+
+        EX.spawn(async move {
+            let addr = "127.0.0.1:25565".parse().unwrap();
+            let stream = dbg!(TcpStream::connect(&addr).await);
+            match stream {
+                Err(_) => tx2.send(Err(())).unwrap(),
+                Ok(_) => tx2.send(Ok(())).unwrap(),
+            }
         });
 
         assert_eq!(rx.recv(), Ok(Ok(())));
+        assert_eq!(rx2.recv(), Ok(Ok(())));
     }
 }

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -247,10 +247,10 @@ mod tests {
         EX.spawn(async move {
             let addr = "10.0.0.1:80".parse().unwrap();
             let stream = TcpStream::connect(&addr).await;
-            let _ = dbg!(stream);
-            tx.send(0).unwrap();
+            let res = dbg!(stream).map(|_| ()).map_err(|_| ());
+            tx.send(res).unwrap();
         });
 
-        assert_eq!(rx.recv(), Ok(0));
+        assert_eq!(rx.recv(), Ok(Ok(())));
     }
 }

--- a/src/reactor/background.rs
+++ b/src/reactor/background.rs
@@ -23,7 +23,7 @@ pub struct Background {
 impl Background {
     /// Creates a new background thread which polls the given
     /// reactor. All errors returned during the creation of
-    /// the `ReactorThread` will be propogated.
+    /// the `ReactorThread` will be propagated.
     pub fn new(mut reactor: Reactor) -> io::Result<Self> {
         let (reg, wakeup) = Registration::new2();
         let reactor_handle = reactor.handle();
@@ -99,7 +99,6 @@ impl Background {
 
 impl Drop for Background {
     fn drop(&mut self) {
-        self.shutdown.store(true, Ordering::Relaxed);
         let _ = self.shutdown_now();
     }
 }

--- a/src/thread_pool/mod.rs
+++ b/src/thread_pool/mod.rs
@@ -9,10 +9,7 @@ use crossbeam::{
 use futures::Future;
 use std::{
     io,
-    sync::{
-        atomic::{Ordering},
-        Arc,
-    },
+    sync::{atomic::Ordering, Arc},
     thread::JoinHandle,
 };
 use task::Task;
@@ -200,14 +197,14 @@ pub(crate) struct Shared {
 mod tests {
     use super::*;
     use crossbeam::channel;
-    use futures::task::{Context, Waker};
     use futures::future;
+    use futures::task::{Context, Waker};
     use parking_lot::Mutex;
     use std::pin::Pin;
     use std::sync::atomic::AtomicBool;
     use std::task::Poll;
-    use std::time::{Duration, Instant};
     use std::thread;
+    use std::time::{Duration, Instant};
 
     static TIMES: usize = 100;
 
@@ -245,10 +242,7 @@ mod tests {
                     }
                 });
 
-                CustomFuture {
-                    waker,
-                    shared,
-                }
+                CustomFuture { waker, shared }
             }
         }
 

--- a/src/thread_pool/mod.rs
+++ b/src/thread_pool/mod.rs
@@ -291,6 +291,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn bad_future() {
         // A future that spawns a thread, returns Poll::Ready(()), and
         // keeps trying to reschedule itself on the thread_pool.

--- a/src/thread_pool/task/mod.rs
+++ b/src/thread_pool/task/mod.rs
@@ -3,7 +3,7 @@ mod waker;
 
 use super::Shared;
 use futures::{self, future::Future, task::Waker};
-use raw::{Header, InvalidGuard, PollGuard, RawTask};
+use raw::{Header, InvalidGuard, RawTask};
 use std::{sync::Weak, task::Context};
 
 pub fn waker(task: &Task) -> Waker {
@@ -31,16 +31,8 @@ impl Task {
         Self { raw }
     }
 
-    pub(super) fn guard(&self) -> PollGuard {
-        self.raw.lock()
-    }
-
-    pub(super) fn poll<'a>(
-        &self,
-        cx: &'a mut Context,
-        guard: &'a PollGuard,
-    ) -> Result<(), InvalidGuard> {
-        self.raw.poll(cx, &guard)
+    pub(super) fn poll(&self, cx: &mut Context) {
+        self.raw.poll(cx)
     }
 
     unsafe fn from_raw(header: *const Header) -> Self {

--- a/src/thread_pool/task/raw.rs
+++ b/src/thread_pool/task/raw.rs
@@ -37,8 +37,6 @@ impl RawTask {
 
             let vtable_poll = (*(self.ptr)).vtable.poll;
             vtable_poll(self.ptr, cx);
-
-            unlock(self.ptr);
         }
     }
 
@@ -151,8 +149,9 @@ where
         let inner = &*(ptr as *const Inner<F>);
         let future = Pin::new_unchecked(&mut *inner.future.get());
 
-        if let Poll::Ready(()) = future.poll(cx) {
-            set_complete(ptr);
+        match future.poll(cx) {
+            Poll::Ready(()) => set_complete(ptr),
+            _ => unlock(ptr),
         }
     }
 }

--- a/src/thread_pool/worker.rs
+++ b/src/thread_pool/worker.rs
@@ -92,7 +92,7 @@ fn run_tasks(task_queue: &WorkerQueue<Task>, shared: &Shared, state: &AtomicUsiz
             let waker = task::waker(&task);
             let mut cx = Context::from_waker(&waker);
 
-            task.poll(&mut cx, guard);
+            task.poll(&mut cx, &guard).expect("Invalid guard supplied.");
         }
 
         let backoff = Backoff::new();

--- a/src/thread_pool/worker.rs
+++ b/src/thread_pool/worker.rs
@@ -88,11 +88,10 @@ fn run_tasks(task_queue: &WorkerQueue<Task>, shared: &Shared, state: &AtomicUsiz
                 return;
             }
 
-            let guard = task.guard();
             let waker = task::waker(&task);
             let mut cx = Context::from_waker(&waker);
 
-            task.poll(&mut cx, &guard).expect("Invalid guard supplied.");
+            task.poll(&mut cx);
         }
 
         let backoff = Backoff::new();

--- a/src/utils/thread_parker.rs
+++ b/src/utils/thread_parker.rs
@@ -23,7 +23,7 @@ pub fn new2() -> (ThreadParker, ThreadUnparker) {
 /// use threader::utils::thread_parker;
 ///
 /// fn main() {
-///     let (parker, unparker) = thead_parker::new2();
+///     let (parker, unparker) = thread_parker::new2();
 /// }
 /// ```
 pub struct ThreadParker {


### PR DESCRIPTION
This PR adds TcpListener and slightly changes the semantics of polling a task. Before, a guard was required to poll the task, but now the poll function automatically locks the task. This is similar to what was done before, with the old task system.